### PR TITLE
Add android xml namespace specification

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="com.aerserv.sdk.plugins.phonegap" version="1.2">
 	<name>Aerserv</name>
 	<description>AerServ SDK Plugin</description>


### PR DESCRIPTION
Without this AppBuilder's XML parser rejects the file because of the unknown _android_ namespace.
